### PR TITLE
Update roswire to new ROS version API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
 install:
 - pip install -r requirements.dev.txt
 - pip install -e .
+# https://travis-ci.community/t/cant-deploy-to-pypi-anymore-pkg-resources-contextualversionconflict-importlib-metadata-0-18/10494/4
+- pip install keyring==21.4.0
 # see #337: flag potential twine issues before attempting to upload to PyPI
 - python setup.py sdist
 - python setup.py bdist_wheel

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -7,4 +7,4 @@ tox==3.15.1
 coveralls==2.0.0
 twine==3.1.1
 wheel==0.34.2
-git+git://github.com/ChrisTimperley/roswire.git@36559ff4e3cd6464371671b4b7a95ec2f19d9c83
+git+git://github.com/ChrisTimperley/roswire.git@837fdc4772c40fed9e6a493f8807d41ca8596d7f

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -7,4 +7,4 @@ tox==3.15.1
 coveralls==2.0.0
 twine==3.1.1
 wheel==0.34.2
-git+git://github.com/ChrisTimperley/roswire.git@d69f3e6729a8aecaa76ca4122a218c9cb4269097
+git+git://github.com/ChrisTimperley/roswire.git@ad720153c0a15555cfcd5a765f8bef93e76211f5

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -7,4 +7,4 @@ tox==3.15.1
 coveralls==2.0.0
 twine==3.1.1
 wheel==0.34.2
-git+git://github.com/ChrisTimperley/roswire.git@837fdc4772c40fed9e6a493f8807d41ca8596d7f
+git+git://github.com/ChrisTimperley/roswire.git@d69f3e6729a8aecaa76ca4122a218c9cb4269097

--- a/src/rosdiscover/interpreter/interpreter.py
+++ b/src/rosdiscover/interpreter/interpreter.py
@@ -50,10 +50,10 @@ class Interpreter:
     def launch(self, filename: str) -> None:
         """Simulates the effects of `roslaunch` using a given launch file."""
         # NOTE this method also supports command-line arguments
-        if self._app.description.distribution.ros == ROSVersion.ros1:
-            reader = ROS1LaunchFileReader.build(self._app)
+        if self._app.description.distribution.ros == ROSVersion.ROS1:
+            reader = ROS1LaunchFileReader.for_app_instance(self._app)
         else:
-            reader = ROS2LaunchFileReader.build(self._app)
+            reader = ROS2LaunchFileReader.for_app_instance(self._app)
 
         config = reader.read(filename)
 

--- a/src/rosdiscover/interpreter/interpreter.py
+++ b/src/rosdiscover/interpreter/interpreter.py
@@ -3,9 +3,10 @@ from typing import Dict, Iterator, Optional
 import contextlib
 
 from loguru import logger
-from roswire import AppInstance
-from roswire.proxy.roslaunch.reader import LaunchFileReader
 import roswire
+from roswire import AppInstance, ROSVersion
+from roswire.ros1.launch.reader import ROS1LaunchFileReader
+from roswire.ros2.launch.reader import ROS2LaunchFileReader
 
 from .context import NodeContext
 from .model import Model
@@ -49,8 +50,11 @@ class Interpreter:
     def launch(self, filename: str) -> None:
         """Simulates the effects of `roslaunch` using a given launch file."""
         # NOTE this method also supports command-line arguments
-        reader = LaunchFileReader(shell=self._app.shell,
-                                  files=self._app.files)
+        if self._app.description.distribution.ros == ROSVersion.ros1:
+            reader = ROS1LaunchFileReader.build(self._app)
+        else:
+            reader = ROS2LaunchFileReader.build(self._app)
+
         config = reader.read(filename)
 
         for param in config.params.values():


### PR DESCRIPTION
There were recent changes made in `roswire` to handle both ROS1 and ROS2 distributions. These require some API changes to clients. This pull request reflects those changes.